### PR TITLE
fix reference to XSD datatypes

### DIFF
--- a/resource_types/v1_1/coar_resourcetypes_skos-xl.rdf
+++ b/resource_types/v1_1/coar_resourcetypes_skos-xl.rdf
@@ -23924,4027 +23924,4027 @@ A memorandum can have only a certain number of formats; it may have a format spe
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_27ffe9ae">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-18T13:26:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-18T13:26:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_7cb9e117">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-18T13:26:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-18T13:26:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_118f5a51">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:20:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:20:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_2526cc73">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:23:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:23:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_9baf3dfa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:25:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:25:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_1fa39ca6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:25:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:25:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_566fa569">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:28:40Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:28:40Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_1744800a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:28:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:28:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_56c8d6b8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:34:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:34:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_749d00bf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:36:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:36:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6c1123bc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:58:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-20T08:58:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_12100c5c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-21T11:10:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-21T11:10:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_833afd8f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:32:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:32:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_ac617c08">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:32:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:32:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_2ab56251">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:32:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:32:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_1efe840a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:33:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:33:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_021bac06">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:33:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:33:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_6a3de036">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:33:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:33:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_ad99d3fa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:33:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:33:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_64c223da">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:34:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:34:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_1ca2482c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:34:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:34:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_1edd0657">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:35:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T10:35:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_c208986b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T11:28:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T11:28:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_6b231496">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T11:29:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T11:29:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_a6536b5e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T11:29:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T11:29:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_72e46dc4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T11:30:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-22T11:30:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_94e79144">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:16:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:16:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e8fb375b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:42:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:42:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_2f09986c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:48:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:48:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_2d984075">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:54:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:54:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_0a640da5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:54:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:54:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_d69abfa9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:55:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:55:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_0a92918e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:56:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:56:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_eb3d556e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:57:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T18:57:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_d52efcfe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:00:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:00:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_16173933">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:02:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:02:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_c41e63e5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:02:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:02:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_3b1f48b8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:03:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:03:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_23a672d0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:04:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:04:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b4ed86d2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:09:19Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:09:19Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b75b2192">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:14:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:14:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_06ac0f8f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:15:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:15:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6e5a9ea9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:16:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:16:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_12c72858">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:18:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:18:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_36aec3c5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:23:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:23:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8dbf2aeb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:23:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:23:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_304ecea2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:24:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:24:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a94a94f1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:24:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:24:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_d263a4ea">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:26:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:26:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_eb9f352d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:26:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:26:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8ab2549d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:26:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:26:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e58a8a71">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:27:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:27:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_05902223">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:45:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:45:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_31275669">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:46:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:46:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7ea972b5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:47:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:47:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_5193a61a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:48:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-05-27T19:48:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_fff7fe06">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:07:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:07:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_29ce9f44">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:07:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:07:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_1c733c44">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:12:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:12:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_60c1890b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:17:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:17:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_fffe4412">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:17:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:17:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_04056eb0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:17:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:17:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_4d19ec74">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:19:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:19:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_c8671c7d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:24:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:24:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_bb5bb200">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:25:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:25:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_026436c6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:27:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:27:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_cadbad49">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:33:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:33:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_2ad31372">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:35:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:35:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_8671ca2d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:36:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:36:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_f485e560">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:40:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:40:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_3aacec24">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:40:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:40:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_860253c8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:40:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:40:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_aa0084b7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:41:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:41:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_1e9d7e48">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:47:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:47:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_06d8a95d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:54:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T11:54:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_f1ff546a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:24:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:24:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_14defb32">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:24:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:24:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_d9f1d658">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:26:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:26:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_79e516dd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:37:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:37:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_9161e3a8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:37:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:37:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_33482eef">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:38:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:38:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_035efd1a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:45:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T12:45:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_76e7b0fe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:00:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:00:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_473c3463">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:00:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:00:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_95868966">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:04:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:04:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_7aa9a77b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:12:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:12:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_002d251f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:13:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:13:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_ef5903ad">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:13:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:13:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_7dcbd30b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:14:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:14:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_3a5b1f50">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:14:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:14:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_16ed5f42">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:17:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:17:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_87da7749">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:23:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:23:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_1cf42b56">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:29:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:29:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_f68e92f0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:30:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:30:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_945a1a7a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:30:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:30:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_46e05e25">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:31:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:31:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_2a2457e3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:31:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:31:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_458df5b8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:38:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:38:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_de057efe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:38:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:38:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_729f2e18">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:39:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:39:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_cf1b22c1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:39:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:39:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_db3239ba">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:40:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:40:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_a42ebb6e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:42:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:42:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_5b8e8212">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:42:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:42:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_156fb626">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:49:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:49:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_c1177948">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:52:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:52:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_52a27cab">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:55:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:55:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_25acc9e0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:55:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-01T13:55:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_75406f6f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-02T08:56:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-02T08:56:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_51aa665b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:53:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:53:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_4c3ec435">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:53:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:53:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_74daa3ab">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:54:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:54:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_130a9abb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:55:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:55:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_795cb340">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:55:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:55:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_9fef357e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:55:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:55:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_795eb7cb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:55:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:55:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_56c5d3b7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:55:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:55:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_7e7a6846">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:56:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:56:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_4df9775a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:56:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:56:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_055e45ed">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:57:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:57:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_ee32a591">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:57:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:57:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_920ec638">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:57:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:57:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_0058fd45">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:58:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:58:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_7199b0fd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:58:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:58:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_3d5c8c0f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:59:19Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:59:19Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_a4dd8a4a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:59:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:59:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_9c1a8689">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:59:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T09:59:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_c8e1d122">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:00:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:00:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_4bfc481c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:00:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:00:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_9c789b5c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:00:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:00:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_a894beb7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:00:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:00:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_b97d18c6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:01:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:01:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_fdb41dc7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:01:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:01:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_3885222a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:01:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:01:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_94bbf8f5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:02:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:02:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_383e47f4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:02:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:02:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_ec294952">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:02:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:02:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_a9507f77">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:02:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:02:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_7231f5aa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:02:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:02:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_bab0dd08">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:03:19Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:03:19Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_cecd2fa7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:03:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:03:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_962d0947">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:03:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:03:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_8bce0f63">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:03:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:03:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_4446dc01">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:03:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:03:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_8f0ad39f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:05:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:05:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_cc32038d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:05:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T10:05:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_001ffd97">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T13:19:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T13:19:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_dcd4b863">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T13:40:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T13:40:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_0da749bb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T13:51:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T13:51:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8bd9e693">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T13:55:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T13:55:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7d512c75">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T13:57:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T13:57:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8163170d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:06:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:06:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_07015141">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:07:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:07:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4b36e122">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:07:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:07:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_22c2fd9c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:07:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:07:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_acf04dc4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:13:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:13:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_16a3312a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:16:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:16:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b8672bbc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:17:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:17:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_9f5dccbd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:20:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:20:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_18dfffbe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:24:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:24:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a72b087d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:24:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:24:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b71ecbb2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:25:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:25:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_ef4cb6a4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:26:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:26:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7bb64b64">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:27:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:27:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6b784f81">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:28:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:28:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b440f611">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:28:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T14:28:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_6345c810">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:29:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:29:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_79d5186f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:31:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:31:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_deca8fb8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:37:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:37:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_34007494">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:38:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:38:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_0520d025">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:41:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:41:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_98561ed5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:49:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:49:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_c3ef04a3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:49:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:49:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_a384b2de">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:50:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:50:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_7e597520">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:51:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:51:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_42bbbb9e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:53:38Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:53:38Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_c92543d7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:54:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:54:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_4980f879">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:54:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:54:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_d36cecdd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:55:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:55:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_a561312b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:57:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:57:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_b2191663">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:58:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:58:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_3f170327">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:59:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:59:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_e72d65bb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:59:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T19:59:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_220147e6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:00:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:00:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_b6704719">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:00:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:00:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_1240713c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:02:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:02:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_281b31d2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:03:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:03:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_567415a0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:04:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:04:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_f824773a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:05:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:05:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_c114c9fc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:06:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:06:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_fcc53e9e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:07:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:07:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_82d64b61">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:07:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:07:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_856121fe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:09:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:09:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_0e4f096d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:09:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-03T20:09:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_775fd538">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:38:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:38:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_989259f7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:39:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:39:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_d97799e9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:43:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:43:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_9acb3b81">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:44:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:44:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_15cbbf51">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:45:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:45:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_d02e31a5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:46:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:46:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_3243a413">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:47:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:47:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_bf4f2f9d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:48:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:48:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_0cb286ce">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:49:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:49:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_29c2b079">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:49:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:49:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e7229a65">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:55:38Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:55:38Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8800f930">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:55:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:55:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e9a58650">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:56:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:56:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a7f38ff4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:57:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:57:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8b16574d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:57:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:57:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_1adfbf9f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:59:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T09:59:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_31aba082">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:01:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:01:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_9eaf4cfc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:02:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:02:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a4b8a50b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:05:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:05:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_c7aa47c8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:05:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:05:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4eb028e4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:07:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:07:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_338b7624">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:10:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:10:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_d42938d0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:10:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:10:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_14e34ed7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:11:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:11:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6c404f5f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:14:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:14:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_14ad7182">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:14:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:14:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_cdddffe3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:18:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:18:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4e512bd7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:19:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:19:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_2b06f9c3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:25:38Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:25:38Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_fedea0cd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:28:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:28:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_734ae2c2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:30:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:30:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_1ce2ebab">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:31:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:31:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e6a28b00">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:33:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:33:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_21baad3a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:34:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:34:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_169a6a59">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:36:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:36:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_d1e7c044">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:42:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:42:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_efc070e4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:45:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:45:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_60a69f7e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:48:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:48:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_def1fcdf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:49:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:49:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_0aa124a6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:51:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:51:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_22a57dd7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:52:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:52:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6c183763">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:57:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:57:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_42763ad6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:59:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T10:59:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8fc83787">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:00:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:00:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_ab9e356c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:11:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:11:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_96043a0b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:19:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:19:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a736579e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:20:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:20:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b77e405c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:22:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:22:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4fac35e0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:23:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:23:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_c5be766f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:23:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:23:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8e160f9f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:24:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:24:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_03276b5f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:25:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T11:25:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6a5cd1ed">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:07:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:07:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_df82b0b0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:07:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:07:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_42cc1399">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:08:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:08:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f8465d15">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:09:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:09:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_17f83c3e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:10:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:10:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7673a0ab">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:10:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:10:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4c00f4c4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:14:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:14:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_886319a4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:18:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:18:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_784ba284">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:22:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:22:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_d15b505d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:23:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:23:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_5d2586f8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:26:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:26:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_227f8913">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:28:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:28:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_2937ac7f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:28:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:28:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a52091da">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:28:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:28:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_817b70a4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:30:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:30:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_2a630f85">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:33:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:33:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_60fd3d26">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:58:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T12:58:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_bf85685d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T13:01:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T13:01:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4c3a7dab">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T13:02:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T13:02:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_45468335">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T13:02:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T13:02:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_14e49eaf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T13:02:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T13:02:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_ff4f1e2f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T13:04:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T13:04:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_ce18f62a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T13:07:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T13:07:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_75f79a61">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T14:43:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T14:43:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_46b17d1e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T14:48:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T14:48:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_926dafe7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T14:49:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T14:49:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_ec34898e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:00:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:00:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_1e7a29a2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:02:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:02:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_340a12df">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:04:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:04:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_952f9132">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:05:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:05:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e4236acf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:05:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:05:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_291746a1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:06:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:06:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_af3ebe91">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:09:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:09:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_3d241844">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:12:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:12:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_35ad0e4c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:18:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:18:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b191a3a3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:19:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:19:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_1fd58ce7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:26:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-10T15:26:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e5a6d374">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-30T09:53:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-30T09:53:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_9ef306ed">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-30T09:55:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-30T09:55:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f5e3ffcf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-06-30T09:55:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-06-30T09:55:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_974063a5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-04T06:09:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-04T06:09:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6744a44b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-10T14:46:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-10T14:46:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_68c979d3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-10T14:48:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-10T14:48:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6dcbcabe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-10T14:53:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-10T14:53:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_4818a031">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:37:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:37:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_12cc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:37:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:37:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_ff763bd3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:38:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:38:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_12cd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:38:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:38:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_b9e43a27">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:40:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:40:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18cf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:40:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:40:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_42bc865b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:40:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:40:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18cw">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:40:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:40:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_a0360647">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:40:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:40:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_33ee58cf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:41:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:41:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18cc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:41:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:41:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_33884170">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:42:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:42:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18cd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:42:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:42:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_b7e97886">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:44:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:44:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_12ce">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:44:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:44:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_3fa766d7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:45:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:45:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_8b7fd8f1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:49:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T13:49:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_c479a652">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:27:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:27:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18cp">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:27:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:27:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_148df5dc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:27:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:27:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_435251bb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:28:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:28:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18co">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:28:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:28:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_d8755ed0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:30:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:30:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18ws">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:30:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:30:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_28890e6e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:32:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:32:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18gh">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:32:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:32:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_37fbe216">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:32:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:32:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_186u">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:32:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:32:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_6f26915b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:33:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:33:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18op">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:33:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:33:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_42ac2471">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:33:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:33:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18ww">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:33:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:33:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_28676f40">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:33:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:33:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18hj">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:33:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:33:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_6e6b69e9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:34:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:34:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18wz">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:34:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:34:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_2250c766">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:34:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:34:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_18wq">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:34:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-17T14:34:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_0b6accde">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:00:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:00:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e322209d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:29:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:29:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e72bb5de">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:33:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:33:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_1e618ef1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:36:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:36:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_ca39730e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:36:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:36:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7249de13">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:40:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:40:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_ba63551a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:45:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:45:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_70c61781">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:47:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:47:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_61989023">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:48:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:48:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_3ef359ce">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:49:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:49:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4f904174">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:49:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:49:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7443a331">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:50:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T11:50:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a313dd11">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:18:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:18:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_9802678c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:24:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:24:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_5171b490">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:24:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:24:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_24fcdf14">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:25:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:25:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_ac135cb9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:25:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:25:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_1fafdd63">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:25:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:25:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_2a68eb6d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:28:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:28:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_304ed97b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:34:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:34:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e6d0b905">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:37:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:37:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_afb9c5d7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:37:19Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:37:19Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_bcfad4ba">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:38:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:38:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_9c5c8c32">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:38:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:38:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_2c06a216">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:38:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:38:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7c2650fd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:42:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:42:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_710b87ac">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:49:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:49:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_74d23776">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:53:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:53:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f1f76a03">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:54:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T13:54:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b550edf6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:00:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:00:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f9c8cbd8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:02:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:02:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e6ea125e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:03:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:03:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8949e9e5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:03:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:03:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b4b4b43b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:11:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:11:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_47553f3c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:27:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:27:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_42f3daaa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:40:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:40:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_93a5163c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:44:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:44:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_95243967">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:45:38Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:45:38Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_5ed40798">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:48:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:48:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f5c3a064">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:54:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:54:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e67ca1c5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:55:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:55:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_54054bc7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:55:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:55:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f47ced93">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:57:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:57:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e9b5fb43">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:58:19Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T14:58:19Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_93368595">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T15:00:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T15:00:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e4755344">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T15:00:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T15:00:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_91f464b5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T15:01:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T15:01:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b5e18815">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T15:02:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T15:02:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a16fb432">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:35:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:35:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_67e50452">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:36:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:36:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_cadad4a9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:39:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:39:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_de3b8198">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:40:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:40:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7bd079bf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:40:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:40:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f058b9c4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:41:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:41:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_fb0fc0fa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:42:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:42:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_85963f8d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:42:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:42:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_5e9a86fa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:47:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:47:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b32c7081">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:47:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:47:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_46790d18">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:47:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:47:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b37d60aa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:49:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:49:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f5ee00d8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:51:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:51:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_5ec0335f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:52:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:52:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_cd608df1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:53:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:53:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7f3e95c2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:56:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:56:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_89ceabb0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:58:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:58:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7404b6eb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:58:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:58:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_af00680f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:59:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T22:59:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_dfeccb20">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:00:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:00:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6687a564">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:10:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:10:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_fe7f20d7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:13:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:13:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e56dec48">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:16:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:16:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6b625043">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:17:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:17:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4e5f89bc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:22:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:22:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8c2e000b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:24:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-20T23:24:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_5408d1a2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:09:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:09:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_613e1373">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:14:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:14:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_78c6084c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:16:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:16:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_00bb4d51">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:17:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:17:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a94d00a7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:17:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:17:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a2cf5fa8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:18:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:18:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_2ea687b5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:19:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:19:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_77048a51">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:20:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:20:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_5fb87504">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:21:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:21:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8986a8e9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:21:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:21:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7cecb770">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:23:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:23:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_1a46f08f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:24:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:24:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a48acd73">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:25:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:25:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_0621528e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:27:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:27:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_72405383">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:30:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:30:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6ee7febd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:30:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:30:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_9f2ca54c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:35:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:35:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_3a3333f1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:39:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:39:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_0d4f03c5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:43:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:43:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_fa25a774">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:46:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:46:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_71edb1c1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:46:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:46:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_ea500e19">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:47:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:47:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6a4ff07a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:48:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:48:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_5c0de454">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:50:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:50:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7c40f5e4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:52:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:52:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b184685b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:54:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:54:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e06f135a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:56:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:56:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b01634c2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:59:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T09:59:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8799bc6b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:01:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:01:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_eb710cab">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:02:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:02:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f81844c3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:03:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:03:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f0a69cc2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:04:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:04:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_085ccc39">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:05:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:05:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_d44abcbe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:06:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:06:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_94b67813">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:09:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:09:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7ddd8b31">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:14:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:14:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_10a36eee">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:16:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:16:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_292e4277">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:17:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:17:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_9adf5654">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:20:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:20:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e7722d98">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:20:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:20:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_d450d7de">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:25:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:25:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f5b5ff24">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:26:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:26:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4f16c718">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:26:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:26:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_29879c5f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:27:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:27:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_c2511342">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:28:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:28:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e2665e2d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:29:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:29:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_15ca3691">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:33:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:33:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4d67eb1a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:37:38Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:37:38Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_0cc2ef60">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:39:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:39:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b4077ce1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:44:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:44:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4eb93eef">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:44:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:44:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f9239e87">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:44:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:44:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_1dbb6eac">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:47:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:47:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a28f84c9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:48:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:48:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_5d522b60">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:50:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:50:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7d82a2c3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:51:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:51:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_db27bfbe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:51:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:51:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a9ff3934">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:52:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:52:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_fabe4d74">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:52:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:52:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a8d63922">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:53:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:53:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8f35c930">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:53:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:53:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_197a8900">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:54:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:54:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_def72b05">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:54:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:54:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_c04c0fb1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:55:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:55:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_962cdf6b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:56:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:56:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_db5979a1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:56:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T10:56:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_ce6ca1c7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:01:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:01:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a9dd3dce">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:03:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:03:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_29c39375">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:04:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:04:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8832d412">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:04:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:04:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f8792dc9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:04:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:04:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_bd1d64f2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:05:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:05:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_586e05a3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:06:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:06:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6f3147c0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:06:40Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:06:40Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_ee5bfdee">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:07:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:07:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_948d33de">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:07:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:07:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_d4be54a8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:17:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:17:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_23213f1c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:22:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:22:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_33b7f28a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:39:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:39:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_87a0d23c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:40:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:40:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f15dcd47">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:41:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:41:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4729774e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:42:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:42:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_96295fe3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:44:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:44:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6aea70f6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:48:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:48:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a4eab1bc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:53:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:53:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_29fd7a33">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:59:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T11:59:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_026474ea">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:01:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:01:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_18737bd1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:06:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:06:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_adea90ac">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:07:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:07:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_65d35029">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:08:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:08:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_88f1be48">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:09:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:09:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b638c5a2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:19:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:19:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_e8c4c075">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:23:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:23:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4124a334">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:27:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:27:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_6c386aaa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:29:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:29:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_26b6dd5d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:32:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:32:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_37c961da">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:37:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:37:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a6a0df84">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:42:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:42:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_b9685c3b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:43:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:43:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_c97219e7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:49:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:49:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8f59accc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:52:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:52:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_60f2b086">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:54:40Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:54:40Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_5d216679">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:55:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:55:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_dccdb3e7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:55:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:55:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_7138fd41">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:56:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:56:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_53a85cb7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:59:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T12:59:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_db9c80fe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:07:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:07:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_8c77798d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:08:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:08:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_36f26cf8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:08:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:08:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a7a73ed0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:11:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:11:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_2f41a933">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:11:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:11:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_61948f58">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:13:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:13:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_328821ac">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:13:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:13:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4725ef43">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:17:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-21T13:17:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_fc9811db">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:23:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:23:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_a9f28f26">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:24:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:24:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_d2953db0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:25:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:25:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_4e6fdbb4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:26:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:26:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_8e4f45e0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:27:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:27:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_598004c0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:31:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:31:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_2350aaa9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:32:40Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:32:40Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_d95f7e36">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:33:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:33:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_a7fee35b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:33:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:33:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_de702c30">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:34:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:34:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_1b520e8a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:34:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:34:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_484958f1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:34:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:34:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_84954501">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:35:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:35:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_724b94e3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:35:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:35:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_03bf2048">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:35:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:35:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_4060cb72">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:38:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:38:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_23a86b2f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:39:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:39:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_0feef958">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:39:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:39:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_d64bd6db">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:39:38Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:39:38Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_ed3dc30e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:40:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:40:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_e9e4d6de">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:41:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:41:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_41d89c8f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:42:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:42:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_a1f846b4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:42:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:42:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_c7e47fb8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:43:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:43:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_f06a9e61">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:43:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:43:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_2a873111">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:44:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:44:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_37a1c58c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:44:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:44:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_da40e6fa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:45:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:45:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_fb39db9e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:45:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:45:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_7cf90f4f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:45:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:45:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_6afa3865">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:46:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T10:46:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_f63f2407">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:24:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:24:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_7ebf5363">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:24:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:24:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_468ae248">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:27:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:27:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_6a3298f8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:32:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:32:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_5f236d4a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:33:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:33:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_b6f43c37">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:33:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:33:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_e5104183">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:33:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:33:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_8faee57f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:33:40Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:33:40Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_b87cef5b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:35:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:35:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_99f06a9b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:35:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:35:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_48b65a57">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:37:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:37:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_76d1e0f5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:43:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:43:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_ff5aa8a7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:43:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:43:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_6935b9c5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:43:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:43:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_2006898f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:44:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:44:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_0e5fdd7e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:45:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:45:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_1c348955">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:45:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:45:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_01e8b863">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:45:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:45:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_09b55257">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:46:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:46:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_eeacb8dc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:46:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:46:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_07e0ea98">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:47:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:47:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_bce620e6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:47:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:47:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_47805947">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:48:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:48:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_0678a0de">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:50:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:50:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_50bfb146">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:55:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:55:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_694d89dc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:55:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:55:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_fe13ec93">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:57:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:57:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_350653d3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:57:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:57:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_136439a5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:58:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T11:58:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_4485e12a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T12:08:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-23T12:08:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_5aa28c52">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:56:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:56:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_95261ba8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:56:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:56:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_54df7098">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:56:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:56:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ca_da1560c5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:57:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:57:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_99c4e955">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:57:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:57:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_aadd33d2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:57:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:57:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_5cedb13f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:58:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:58:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_60a84869">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:58:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:58:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_cd1b8fa8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:59:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-24T11:59:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_02af11c1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:42:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:42:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_d964768e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:44:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:44:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_2dee0074">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:49:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:49:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_0c276d46">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:50:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:50:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_00917725">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:58:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:58:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_1330364d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:58:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:58:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_70a5cdce">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:58:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T10:58:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_f1e637c3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:04:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:04:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_7c1d0f98">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:07:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:07:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_2426b54f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:07:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:07:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_dfed2cdc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:10:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:10:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_0c524783">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:13:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:13:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_5845e5e0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:18:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:18:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_df1f893a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:27:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:27:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_fc8c84b4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:29:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:29:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_2a91e197">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:37:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:37:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_493fd349">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:40:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:40:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_10201ac3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:43:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:43:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_84f80dbb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:48:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:48:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_0d3c7187">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:49:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:49:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_f21e59c4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:51:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:51:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_37f56dc8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:52:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:52:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_5e519779">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:53:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:53:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_5c755691">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:54:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:54:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_49379800">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:55:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:55:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_71ae7d87">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:56:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:56:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_221a43f9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:56:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:56:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_7fa894e0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:57:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:57:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_5ce04ddd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:59:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T11:59:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_7b854dd7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:00:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:00:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_cbd847cb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:04:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:04:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_49e69ae9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:05:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:05:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_25ea452d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:09:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:09:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_959705aa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:09:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:09:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_415e2c07">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:10:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:10:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_9d621784">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:10:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:10:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_4380f5e1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:11:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:11:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_890ecf99">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:14:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:14:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_fd020083">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:15:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:15:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_5f845b36">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:16:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:16:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_1b03db33">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:16:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:16:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_dc69331e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:20:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-26T12:20:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_acae4720">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:05:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:05:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_5d369cef">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:05:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:05:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_73104cd4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:05:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:05:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_5f5a3983">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:05:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:05:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_743661ca">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:06:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:06:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_170cab40">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:06:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:06:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_7ac6223b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:09:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:09:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_038f3cb0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:10:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:10:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_6d492f3a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:10:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:10:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_e81ae59c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:10:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:10:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_ab86a505">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:11:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:11:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_42716976">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:11:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:11:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_3ecff1bc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:11:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:11:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_90838ca4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:12:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:12:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_70484c25">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:13:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:13:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_d3d3a091">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:14:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:14:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_415cc26a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:14:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:14:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_6f217c82">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:14:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:14:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_d1f4fc12">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:16:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:16:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_d89f6880">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:17:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:17:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_965c2410">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:17:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:17:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_28458811">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:18:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:18:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_84ed2d79">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:18:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:18:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_07bb2925">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:19:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:19:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_17c68768">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:20:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:20:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_c76ab6e7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:21:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:21:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_0d0094fc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:21:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:21:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_2202cc19">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:22:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:22:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_6f9dbea1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:22:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:22:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_it_4fdf6678">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:38:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T07:38:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_e703bb66">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:41:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:41:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_38707d98">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:43:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:43:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_98f73df7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:44:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:44:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_6d9a8f7b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:46:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:46:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_ab5f8d8c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:47:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:47:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_7162200c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:52:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:52:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_1c1506e8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:55:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:55:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_731fc369">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:59:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T09:59:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_671ec616">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:01:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:01:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_101fa178">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:02:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:02:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_6af0dd8b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:03:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:03:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_07d98fc9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:04:19Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:04:19Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_93f2688c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:04:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:04:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_851e6c53">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:07:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:07:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_e379de7d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:08:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:08:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_58846158">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:58:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T10:58:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_583d6528">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:00:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:00:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_3ba5276f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:01:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:01:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_8a7f67b4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:02:40Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:02:40Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_4975af0f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:03:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:03:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_92fbba28">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:03:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:03:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_b252708a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:04:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:04:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_9579905b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:05:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:05:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_01c1cd5b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:06:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:06:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_9121cf33">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:08:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T11:08:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_e4240439">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:14:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:14:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_3d71872a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:17:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:17:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_0e701280">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:19:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:19:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_ff373250">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:25:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:25:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_1423d131">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:26:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:26:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_eb8e4364">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:28:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:28:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_a091af1a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:28:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:28:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_f42e0e76">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:28:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:28:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_ca62c2e0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:29:38Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:29:38Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_112916f8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:29:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:29:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_da6f91b0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:30:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:30:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_2db43d33">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:41:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:41:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_9abadddb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:43:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:43:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_3954f13a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:44:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:44:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_7ddac9ba">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:45:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:45:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_1102ef67">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:47:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:47:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_2b566088">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:50:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:50:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_015f0636">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:53:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:53:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_b93cee1f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:53:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:53:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_3bc998d1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:53:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:53:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_654fcbe1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:56:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:56:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_0adbc49b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:57:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:57:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_a7e133e3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:57:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T12:57:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_c76cca73">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:01:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:01:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_50422786">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:02:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:02:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_3eff2773">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:02:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:02:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_e7f8864a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:02:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:02:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_93bc37d4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:02:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:02:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_286b817c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:03:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:03:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_8dfe532a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:03:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:03:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_3679485e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:03:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:03:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_43f6388f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:04:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:04:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_10b20b19">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:04:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:04:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_55d45e19">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:04:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:04:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_a8d7a8a4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:04:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:04:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_c7c8f6f3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:04:40Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:04:40Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_0dd82a1f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:04:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:04:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_41c43899">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:05:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:05:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_229a201e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:06:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:06:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_f7fe03cf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:06:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:06:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_9a47821e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:06:38Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:06:38Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_cfea5aae">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:06:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:06:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_fd294e4d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:09:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:09:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_5f8269f1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:09:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:09:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_f1b97b2f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:09:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:09:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_987c8646">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:09:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:09:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_13defb43">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:09:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:09:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_3471c9d1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:10:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:10:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_6b5800d7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:10:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:10:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_122bc0a7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:10:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:10:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_8986fe86">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:10:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:10:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_8fcb53ef">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:10:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:10:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_2b2f2ff9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_dc176140">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_a25a440e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_36947480">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_6d3b14b7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_68e032e5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_37f1c761">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:11:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_edd2a7bb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:12:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:12:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_d655e8fe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:12:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:12:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_c3dd7882">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:16:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:16:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_d38072af">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:16:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:16:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_a19d609c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:17:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:17:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_36b19f58">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:17:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:17:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_44367048">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:18:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:18:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_84abe356">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:18:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:18:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_a2507d34">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:18:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:18:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_9ed2d829">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:19:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:19:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_a0c6a95d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:19:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:19:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_c11cb8d3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:19:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:19:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_b5db60a5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:19:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:19:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_1af755ca">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:19:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:19:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_9c0894d0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:20:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:20:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_1c4ece6c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:20:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:20:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_21ef2ed5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:20:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:20:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_2dd1c073">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:22:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:22:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_9e5306b8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:22:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:22:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_42d861bf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:22:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:22:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_6193d31d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:22:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:22:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_2b140d94">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:23:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:23:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_0fa335a4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:23:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:23:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_30baa739">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:23:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:23:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_975a56f3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:24:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:24:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_411ef1b8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:25:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:25:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_5167bb4e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:25:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:25:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_841fa0ee">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:25:38Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:25:38Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_7e6a6142">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:26:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:26:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_d2afa23b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:26:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:26:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_befbf5d8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:26:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:26:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_cc1e2c42">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:27:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:27:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_8fe6a758">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:27:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:27:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_53e619f4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:27:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:27:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_cf69640c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:27:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:27:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_a9fb2473">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:27:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:27:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_d1dca926">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:27:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:27:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_8aee7ca4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:28:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:28:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_e5d435f1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:28:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:28:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_20ee5cc5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:28:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:28:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_9566ef20">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:29:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:29:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_20e94a2e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:29:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:29:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_fed91b32">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:30:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:30:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_c1771640">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:30:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:30:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_4b2aba83">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:30:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:30:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_de4f1415">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:31:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:31:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_cfaa5f40">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:31:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:31:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_7462f92f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:31:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:31:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_6c6056a4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:31:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:31:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_0750bac4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:32:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:32:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_a2041577">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:32:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:32:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_aef535c5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:32:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:32:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_9e4cceea">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:32:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:32:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_4d6f0dae">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:33:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:33:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_52fd91b1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:33:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T13:33:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_08c9858a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:09:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:09:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_b88d40c9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:09:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:09:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_69b1d2c3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:10:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:10:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_96552a01">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:11:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:11:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_373187ce">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:11:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:11:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_caa32607">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:20:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:20:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_0008ed10">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:20:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:20:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_c5683d37">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:20:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:20:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_f82f217b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:22:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:22:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_47b45c62">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:22:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:22:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_eac69b65">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:23:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:23:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_634fa6d5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:25:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:25:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_67c49c22">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:27:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:27:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_5b8b318d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:28:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:28:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_805b2d02">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:28:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:28:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_c53eafb7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:30:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:30:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_8cd417bc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:34:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:34:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_7471b0f0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:35:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:35:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_7a007fae">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:36:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:36:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_368ab6f5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:50:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:50:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_c5141458">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:55:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:55:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_00f8b50f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:56:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:56:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_382c0ba2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:56:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:56:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_82df71fb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:58:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:58:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_910199ab">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:59:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T15:59:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_7e5791b7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:01:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:01:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_6dca50a9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:05:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:05:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_eae9bedd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:08:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:08:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_ea5e33c9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:12:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:12:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_81aa5e7d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:14:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:14:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_0a4d0251">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:18:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:18:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_ab43e233">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:18:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:18:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_c4250d3a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:18:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:18:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_60297959">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:23:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:23:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_ac659c2f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:27:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:27:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_0df24dc8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:39:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:39:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_a959798d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:43:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:43:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_a955918d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:47:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:47:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_4a21da4b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:47:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:47:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_4e1e4347">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:48:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:48:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_eb5838bc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:48:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:48:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_d5f2875f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:50:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:50:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_bd0ba1a6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:50:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:50:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_f88b3373">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:51:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:51:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_0a95cc01">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:51:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:51:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_c347e22a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:52:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:52:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_ea2ef03d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:53:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:53:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_28e16c4b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:53:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:53:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_5f6f832e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:57:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:57:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_83b6003a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:57:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:57:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_ea52ff7b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:58:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:58:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_67db0aed">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:59:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T16:59:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_2470f43f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:00:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:00:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_d5e7ae52">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:02:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:02:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_f4dd8758">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:04:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:04:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_e83fa9b1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:04:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:04:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_b3d78fed">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:05:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:05:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_0dd8aef8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:05:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:05:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_2b9e1b7a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:06:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:06:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_17b46a5b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:06:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:06:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_c67ebc03">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:08:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:08:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_d9940fc8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:08:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:08:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_523b129d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:09:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:09:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_b1114e6f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:09:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:09:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_3d097fba">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:11:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:11:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_7952e068">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:11:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:11:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_2c8932f6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:12:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:12:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_3c46dd6c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:15:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:15:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_f150fa8c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:16:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:16:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_e1dc2822">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:23:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:23:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_1d058514">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:23:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:23:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_fa199733">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:24:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:24:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_09b56668">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:24:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:24:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_0bf6b23e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:25:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:25:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_8d35100c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:25:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:25:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_013f957e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:25:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:25:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_5e78944f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:26:30Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:26:30Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_fa9e106b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:26:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:26:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_cea37d6f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:26:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:26:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_6c5acd55">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:27:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:27:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_2b52a36b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:27:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:27:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_cfbd3049">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:28:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:28:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_5f3072a2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:29:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:29:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_49ca123e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:29:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:29:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_3c317765">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:30:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:30:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_03cd3432">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:30:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:30:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_5172ce00">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:30:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:30:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_bb5d6bb0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:30:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:30:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_6f2e24fc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:30:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:30:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_ef944955">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:31:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:31:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_c0b07734">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:32:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:32:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_86030b0d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:32:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:32:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_b5cb095f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:32:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:32:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_bcd03db5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:34:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:34:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_8fbb9d61">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:34:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:34:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_64307524">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:34:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-27T17:34:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_2323cb14">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:35:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:35:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_f0f435e7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:36:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:36:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_9c1c90f1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:37:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:37:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_b8893d8f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:39:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:39:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_1e73f1aa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:40:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:40:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_15fcae06">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:41:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:41:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_a7481778">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:42:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:42:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_ed2672f8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:44:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:44:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_6849cc54">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:44:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:44:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_22668d07">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:45:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:45:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_660bafa0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:46:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:46:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_348f3ab2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:50:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:50:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_f1487273">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:50:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:50:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_fefe3295">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:50:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:50:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_7b94d455">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:54:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:54:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_d30e98e8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:56:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:56:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_21a6f77a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:58:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:58:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_d0a47704">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:59:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:59:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_8819689c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:59:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T07:59:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_d28f43c5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:00:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:00:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_b947ab7a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:09:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:09:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_acf9d9fc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:10:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:10:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_693f153b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:11:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:11:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_fcdea5fe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:12:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:12:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_3ec9d8f4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:13:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:13:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_ed59fff6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:14:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:14:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_cdd1f441">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:15:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:15:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_57d7730b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:15:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:15:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_88ddff0a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:16:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:16:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_7abca0ec">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:17:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:17:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_6231ed20">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:18:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:18:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_7d86b628">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:18:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:18:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_0d009497">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:20:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:20:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_89ed6461">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:22:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:22:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_ffcd01c9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:22:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:22:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_568e8d9c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:22:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:22:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_f099b835">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:23:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:23:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_2036b173">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:24:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:24:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_e6a32d4d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:25:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:25:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_737fc994">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:32:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:32:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_9d4cfa08">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:32:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:32:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_5d9f1cc0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:33:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:33:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_d66ed224">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:35:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T08:35:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_e7af70f3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T10:10:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T10:10:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_bcdcd24c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T10:10:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T10:10:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_7e1189a8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:16:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:16:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_2679d720">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:16:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:16:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_ef903da5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:17:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:17:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_80804d41">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:22:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:22:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_ee0fc2fc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:24:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:24:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_7910bf18">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:24:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:24:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_ff3f7a10">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:25:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:25:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_16498ec8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:30:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:30:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_287f51b2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:33:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:33:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_9740ac26">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:33:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:33:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_f4c375cf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:34:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:34:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_13caa63b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:34:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:34:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_211306fc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:34:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:34:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_085910aa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:35:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:35:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_197b7213">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:36:08Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:36:08Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_d5b1def0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:36:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:36:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_3423aa20">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:36:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:36:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_744ae94a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:37:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:37:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_57fb750e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:40:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:40:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_65eb8fb1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:46:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:46:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_7bad5e4d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:46:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:46:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_eb10b29c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:47:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:47:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_2dec2d67">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:48:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:48:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_f929a63b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:49:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:49:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_8ea6c6ec">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:49:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:49:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_6145ddbf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:49:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:49:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_7d51af52">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:54:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:54:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_1171b86f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:56:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:56:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_6828c882">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:57:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:57:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_724f992c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:57:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:57:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_dc4ebe4e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:57:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:57:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_67d59370">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:59:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:59:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_fb79bd7b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:59:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T14:59:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_57bcfd28">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:04:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:04:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_df7bd982">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:05:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:05:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_ef236a6b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:05:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:05:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_8728fb84">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:06:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:06:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_92f184d8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:15:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:15:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_445594b7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:20:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:20:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_cf7179bc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:20:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:20:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_0903468f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:21:19Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:21:19Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_fa35a389">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:21:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:21:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_bb85af31">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:21:40Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:21:40Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_dce1103d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:21:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:21:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_fa6f8e77">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:23:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:23:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_7982b3f2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:23:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:23:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_e3bfb5ce">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:24:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:24:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_357067b4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:24:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:24:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_d8ed96a6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:25:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:25:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_6023ce99">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:40:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-28T15:40:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_40e940a6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:14:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:14:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_d9e48af6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:18:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:18:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_b1d72daf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:19:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:19:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_c52f988a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:20:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:20:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_73b57dd5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:21:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:21:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_b0b0d6e8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:23:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:23:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_9e4dfd3b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:38:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:38:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_a58f271a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:44:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:44:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_13ea3237">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:44:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:44:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_9d098ca9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:44:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:44:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_a65fbae2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:46:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T08:46:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_424a5436">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T09:01:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T09:01:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_f0185c38">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T11:37:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T11:37:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_292ea0d0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T11:55:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T11:55:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_89c4f769">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T12:14:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T12:14:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_fr_2c6bbb2a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T13:06:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-29T13:06:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_1fe6dec5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-30T07:59:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-30T07:59:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_56f1d1fe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-30T07:59:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-30T07:59:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/def_6f4710ee">
@@ -28056,315 +28056,315 @@ A memorandum can have only a certain number of formats; it may have a format spe
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_2ff085c5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:08:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:08:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_2b52a6bf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:21:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:21:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_d87f78f6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:22:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:22:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_4e704ef1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:23:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:23:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_bce03dd2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:31:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:31:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_08859ead">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:34:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:34:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_f73d72d8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:36:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:36:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_a5ad0f94">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:40:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:40:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_294d4be0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:41:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:41:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_acf35b8a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:41:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:41:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_0b010843">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:42:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:42:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_ad6d15e3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:47:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T13:47:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ru_06d7c405">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T14:06:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-07-31T14:06:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_beef629c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:25:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:25:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_f0bfbe38">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:25:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:25:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_512c298b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:26:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:26:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_eda90c59">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:26:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:26:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_1dab12aa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:27:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:27:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_b38923f7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:29:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:29:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_2571a7d2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:30:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:30:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_6a201e7a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:31:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:31:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_2f8b9d5f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:31:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:31:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_9268a934">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:32:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:32:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_7a8633b3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:34:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:34:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_1edce9b8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:36:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:36:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_1c10a9af">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:37:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:37:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_dc229b92">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:38:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:38:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_6246fc4a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:40:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:40:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_ca7821d3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:41:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:41:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_87162470">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:41:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:41:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_a37f6557">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:41:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:41:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_1bd919da">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:42:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:42:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_b7c145b9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:43:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:43:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_3bcb3529">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:45:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:45:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_aceb3a3f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:45:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:45:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_1370be1f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:46:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:46:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_05572b53">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:46:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:46:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_b535e2b0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:46:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:46:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_c257ade8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:47:11Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:47:11Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_994297e1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:47:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:47:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_8cdc0b0f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:48:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:48:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_b0860f43">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:48:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:48:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_1f732c54">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:48:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:48:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_356b2d66">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:48:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:48:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_de87b7ef">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:49:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:49:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_9a1aa82f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:50:19Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T10:50:19Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_07f643db">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:00:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:00:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_9eb501f2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:02:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:02:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_a8b95a31">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:03:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:03:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_6b415cdc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:04:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:04:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_4ad26462">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:06:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:06:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_7481caa9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:06:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:06:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_13dd8f0e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:06:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:06:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_8b4db0f2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:07:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:07:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_67309aaa">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:07:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:07:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_87c34979">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:08:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:08:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_8e21ebfe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:09:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:09:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_b63af523">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:09:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:09:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_79b2bf7b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:10:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:10:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_49cb5bc7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:11:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:11:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_e80adee5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:11:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:11:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_3b6b4deb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:12:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:12:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_831a7631">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:12:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:12:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_66aa978e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:13:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:13:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_4ca00dcf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:13:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:13:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_6124afdb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:13:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:13:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_ac9f79ff">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:14:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:14:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_1467e51a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:14:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:14:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_4517c321">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:14:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:14:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_3cde0fc8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:15:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:15:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_051af91d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:15:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:15:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_d651edf5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:15:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:15:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_ff3bdcf8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:16:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:16:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_cbfbff1b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:16:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-13T11:16:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_44cd6090">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-15T07:30:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-15T07:30:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_2195b9ae">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-17T07:40:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-17T07:40:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_cb58f964">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-28T10:15:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-28T10:15:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_03601083">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-28T10:17:45Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-28T10:17:45Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/def_e17bc480">
@@ -28372,607 +28372,607 @@ A memorandum can have only a certain number of formats; it may have a format spe
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_2141d75c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T08:54:40Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T08:54:40Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_8a7567bd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T08:55:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T08:55:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_9cafa2b6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T08:55:31Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T08:55:31Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_a41244a8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:04:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:04:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_4b2aa2dd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:04:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:04:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_c2556993">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:04:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:04:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_de7e4751">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:05:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:05:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_6f8cbe9e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:05:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:05:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_79116e63">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:06:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:06:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_d73b99d6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:06:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:06:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_5d6f62ee">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:07:37Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:07:37Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_412d19ae">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:08:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:08:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_2755bed3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:08:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:08:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_cc9c77bb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:08:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:08:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_09fc634b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:09:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:09:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_856b18ac">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:09:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:09:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_92fde54e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:10:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:10:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_28126b66">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:10:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:10:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_70864708">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:11:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:11:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_cfd2db19">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:11:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:11:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_900bd5b8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:11:40Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:11:40Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_cad470a5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:12:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:12:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_e262c4ce">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:12:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:12:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_b45621df">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:13:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:13:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_67afa4df">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:14:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:14:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_3628a3fe">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:14:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:14:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_8f052f78">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:14:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:14:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_df2eb385">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:15:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:15:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_6a8f1725">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:15:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:15:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_d56cff98">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:16:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:16:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_dd61b71d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:16:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:16:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_85d41322">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:17:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:17:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_431a3bbf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:17:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:17:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_e3951b38">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:18:19Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:18:19Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_d0b6a1c2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:18:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:18:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_c8c62e3b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:19:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:19:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_41f2c9f4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:19:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:19:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_22768281">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:20:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:20:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_69fe54e6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:21:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:21:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_9598d0a2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:21:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:21:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_7da5dce9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:22:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:22:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_bca51b49">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:22:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:22:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_f64c3a48">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:22:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:22:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_d313e72a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:23:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:23:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_485fd015">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:23:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:23:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_5a75b957">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:24:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:24:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_ad21ba20">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:25:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:25:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_49497817">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:25:41Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:25:41Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_cdba7c48">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:25:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:25:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_da042e56">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:26:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:26:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_ef843fbd">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:26:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:26:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_67afab25">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:26:57Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:26:57Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_85c8c443">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:28:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:28:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_8b602647">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:28:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:28:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_ja_59557010">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:28:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-09-29T09:28:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_e8620d24">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-07T16:10:49Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-07T16:10:49Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_8643ca02">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-07T16:12:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-07T16:12:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_47d53786">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-07T16:14:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-07T16:14:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_4b5f3272">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-07T16:18:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-07T16:18:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_nl_8a068203">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-07T16:19:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-07T16:19:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_ca338adb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T10:58:20Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T10:58:20Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_7b2fec78">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:01:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:01:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_664c5d44">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:05:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:05:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_10440abb">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:05:19Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:05:19Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_5d43995f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:06:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:06:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_799d1512">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:06:40Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:06:40Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_d1de046c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:07:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:07:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_b93c6c11">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:07:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T11:07:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_44f5bbf1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:47:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:47:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_d9a834b2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:47:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:47:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_b568f20d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:48:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:48:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_316d4c2c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:48:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:48:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_59dd3b44">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:49:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:49:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_4f17531a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:49:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:49:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_b05d07a2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:49:46Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:49:46Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_ca41636b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:50:19Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:50:19Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_ee8330df">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:50:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:50:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_96e01066">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:52:05Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:52:05Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_2c834bbc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:52:33Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:52:33Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_17097d48">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:54:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:54:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_927c9cf6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:54:42Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:54:42Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_4c63504f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:55:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:55:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_ae2705d1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:57:26Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:57:26Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_a0286216">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:57:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:57:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_5317779e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:57:55Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:57:55Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_408700a3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:58:19Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:58:19Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_ba48d992">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:58:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:58:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_79777f12">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:59:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T12:59:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_b8de34f4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:00:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:00:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_2b6bda8f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:00:44Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:00:44Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_6ad18d6f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:01:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:01:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_2f8a8366">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:01:25Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:01:25Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_2959aa98">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:03:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:03:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_0e5b994c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:03:27Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:03:27Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_5e869fba">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:04:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:04:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_ac4a4aed">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:15:34Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:15:34Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_9381b7e4">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:16:40Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:16:40Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_e8d2be8f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:17:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:17:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_ea92bd51">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:24:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:24:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_b19d68c6">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:24:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:24:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_18d5841e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:24:53Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:24:53Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_8dcc2106">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:25:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:25:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_32f06709">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:25:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:25:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_08c4d57d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:26:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:26:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_4da7437b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:26:43Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:26:43Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_6a10a57e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:26:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:26:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_452697bc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:27:32Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:27:32Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_d9a593ba">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:28:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:28:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_91b237a9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:28:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:28:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_535c8eca">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:28:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-10-30T13:28:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_0eecd3f9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-11-26T11:17:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-11-26T11:17:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_949d9adc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-11-26T11:18:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-11-26T11:18:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_30797f7c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-11-26T11:19:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-11-26T11:19:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_af458186">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-11-26T11:19:51Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-11-26T11:19:51Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_tr_87b55f67">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2015-11-26T11:20:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-11-26T11:20:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_566c2b0c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:03:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:03:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_ee89ba7f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:04:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:04:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_9a8c99a3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:05:39Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:05:39Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_9370a7e5">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:06:12Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:06:12Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_dcae04bc">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:43:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:43:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_1bc32323">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:43:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:43:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/c_2df8fbb1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:43:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:43:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_en_9950a271">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:43:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-01-18T14:43:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_6d95ee4b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-02-17T11:19:17Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-02-17T11:19:17Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_de_c114be0b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-02-17T11:20:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-02-17T11:20:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_4687f2b1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:42:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:42:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_0ef5a0a2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:43:28Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:43:28Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_fd0285a1">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:46:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:46:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_696a6259">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:46:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:46:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_49d4bb1e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:49:52Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:49:52Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_843f7267">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:51:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:51:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_6a510345">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:52:01Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:52:01Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_f156518e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:52:56Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:52:56Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_b798e624">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:53:23Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:53:23Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_cfe8d495">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:54:21Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:54:21Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_b7c3c7c3">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:55:14Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:55:14Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_0f5015cf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:58:29Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:58:29Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_a926e7f0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:59:22Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T14:59:22Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_310ba1b7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:03:09Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:03:09Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_a70b96a8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:04:50Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:04:50Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_d806727a">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:05:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:05:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_e8a649b0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:06:06Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:06:06Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_9f324049">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:06:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:06:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_6a68d396">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:07:00Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:07:00Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_fe13c5f2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:07:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:07:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_ceae04f0">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:08:24Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:08:24Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_2a1f1234">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:09:03Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:09:03Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_ab91d176">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:09:18Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:09:18Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_8c8a379f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:09:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:09:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_47430add">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:10:36Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:10:36Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_5d85e539">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:10:58Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-04-21T15:10:58Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xDef_52b28ffa">
@@ -28984,71 +28984,71 @@ A memorandum can have only a certain number of formats; it may have a format spe
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_bac26ff9">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:45:13Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:45:13Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_1e2ad49b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:45:38Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:45:38Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_21917623">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:49:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:49:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_8bdeedf8">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:49:59Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:49:59Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_2447547d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:53:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:53:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_e61c739e">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:54:04Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:54:04Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_3c5e4237">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:55:35Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:55:35Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_7df7bbaf">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:55:47Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:55:47Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_13e4d63f">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:56:48Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:56:48Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_es_f3f4348b">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:57:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T07:57:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_81039bb7">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:38:02Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:38:02Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_d552a638">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:39:15Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:39:15Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_80984134">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:40:07Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:40:07Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_64a03c3c">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:41:16Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:41:16Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_ef13f89d">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:41:38Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:41:38Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_3b6265f2">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:41:54Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:41:54Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_zh_22947d11">
-	<dc-term:created rdf:datatype="xsd:http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:43:10Z</dc-term:created>
+	<dc-term:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-09-27T13:43:10Z</dc-term:created>
 </rdf:Description>
 
 <rdf:Description rdf:about="http://purl.org/coar/resource_type/xl_pt_2526cc73">


### PR DESCRIPTION
To my understanding a datatype is referenced by its URI. The `xsd:` prefix was probably superfluous.